### PR TITLE
fix: apostrophes for gutenberg demos - disable UTF-8  encode for content

### DIFF
--- a/includes/importers/helpers/class-themeisle-ob-importer-alterator.php
+++ b/includes/importers/helpers/class-themeisle-ob-importer-alterator.php
@@ -99,7 +99,7 @@ class Themeisle_OB_Importer_Alterator {
 	 * @return array
 	 */
 	public function encode_post_content( $data, $postarr ) {
-		if ( $this->site_json_data['editor'] === 'gutenberg' ) {
+		if ( isset( $this->site_json_data['editor'] ) && $this->site_json_data['editor'] === 'gutenberg' ) {
 			return $data;
 		}
 		$data['post_content'] = utf8_encode( $data['post_content'] );

--- a/includes/importers/helpers/class-themeisle-ob-importer-alterator.php
+++ b/includes/importers/helpers/class-themeisle-ob-importer-alterator.php
@@ -99,6 +99,9 @@ class Themeisle_OB_Importer_Alterator {
 	 * @return array
 	 */
 	public function encode_post_content( $data, $postarr ) {
+		if ( $this->site_json_data['editor'] === 'gutenberg' ) {
+			return $data;
+		}
 		$data['post_content'] = utf8_encode( $data['post_content'] );
 
 		return $data;


### PR DESCRIPTION
[closes Codeinwp/neve#1268] cc: @rodica-andronache